### PR TITLE
Testing/main page

### DIFF
--- a/cypress/e2e/home-page-spec.cy.ts
+++ b/cypress/e2e/home-page-spec.cy.ts
@@ -1,0 +1,16 @@
+/// <reference types="Cypress" />
+describe('template spec', () => {
+  const sampleJoke = {
+    "id": "R7UfaahVfFd",
+    "joke": "My dog used to chase people on a bike a lot. It got so bad I had to take his bike away.",
+  };
+
+  beforeEach('visit homepage', () => {
+    cy.intercept('https://icanhazdadjoke.com/', sampleJoke)
+    cy.visit('http://localhost:3000')
+  });
+
+  it('passes', () => {
+
+  });
+});

--- a/cypress/e2e/home-page-spec.cy.ts
+++ b/cypress/e2e/home-page-spec.cy.ts
@@ -1,16 +1,57 @@
 /// <reference types="Cypress" />
-describe('template spec', () => {
-  const sampleJoke = {
-    "id": "R7UfaahVfFd",
-    "joke": "My dog used to chase people on a bike a lot. It got so bad I had to take his bike away.",
-  };
 
+const sampleJoke1 = {
+  "id": "R7UfaahVfFd",
+  "joke": "My dog used to chase people on a bike a lot. It got so bad I had to take his bike away.",
+};
+
+const sampleJoke2 = {
+  "id": "R7UfaahVfFe",
+  "joke": "What did the farmer say when he lost his tractor? Where's my tractor?",
+};
+
+describe('home page', () => {
   beforeEach('visit homepage', () => {
-    cy.intercept('https://icanhazdadjoke.com/', sampleJoke)
-    cy.visit('http://localhost:3000')
+    cy.intercept('https://icanhazdadjoke.com/', sampleJoke1)
+      .visit('http://localhost:3000');
   });
 
-  it('passes', () => {
+  // Will need to check for 'HOME' and 'SEARCH''s elements when we decide on which ones to use
+  it('has a header', () => {
+    cy.get('header').contains('h1', 'ZingerZ')
+      .get('header').contains('HOME')
+      .get('header').contains('SEARCH');
+  });
 
+  it('has a homepage with a joke and a joke button', () => {
+    cy.get('.main-joke').contains('My dog used to chase people on a bike a lot. It got so bad I had to take his bike away.')
+      .get('.new-joke-btn').contains('Tell Me Another');
+  });
+
+  it('gets a new joke when the button is clicked', () => {
+    cy.intercept('https://icanhazdadjoke.com/', sampleJoke2)
+      .get('.new-joke-btn').click()
+      .get('.main-joke').contains('What did the farmer say when he lost his tractor? Where\'s my tractor?');
+  });
+});
+
+// Will need to update these tests when we have updated the Error component to use the error state from App.
+describe('home page - sad paths', () => {
+  it('should show an error message when initial fetch request fails on page load', () => {
+    cy.intercept('https://icanhazdadjoke.com/', {
+      statusCode: 404
+    })
+      .visit('http://localhost:3000')
+      .get('h2').contains('ERROR');
+  });
+
+  it('should show an error message when the joke button is clicked and the fetch fails', () => {
+    cy.intercept('https://icanhazdadjoke.com/', sampleJoke1)
+    .visit('http://localhost:3000')
+    .intercept('https://icanhazdadjoke.com/', {
+      statusCode: 404
+    })
+    .get('.new-joke-btn').click()
+    .get('h2').contains('ERROR');
   });
 });

--- a/cypress/e2e/main-page-spec.cy.ts
+++ b/cypress/e2e/main-page-spec.cy.ts
@@ -1,7 +1,0 @@
-/// <reference types="Cypress" />
-
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/cypress/e2e/main-page-spec.cy.ts
+++ b/cypress/e2e/main-page-spec.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="Cypress" />
+
 describe('template spec', () => {
   it('passes', () => {
     cy.visit('https://example.cypress.io')

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/cypress": "^1.1.3",
         "@types/react-router-dom": "^5.3.3",
         "cypress": "^12.9.0"
       }
@@ -3899,6 +3900,16 @@
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
+      "dev": true,
+      "dependencies": {
+        "cypress": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -21133,6 +21144,15 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "dev": true,
+      "requires": {
+        "cypress": "*"
       }
     },
     "@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@types/cypress": "^1.1.3",
     "@types/react-router-dom": "^5.3.3",
     "cypress": "^12.9.0"
   }

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import './Error.css';
 
 function Error() {
   return (
     <section className='error'>
-      <h2>ERRRRRROOOOOAAAAAARRRRRRrrrrrrrr</h2>
+      <h2>ERROR</h2>
     </section>
   );
 }

--- a/src/components/Joke/Joke.tsx
+++ b/src/components/Joke/Joke.tsx
@@ -9,7 +9,7 @@ interface Props {
 const Joke = ({data}:Props) => {
   return (
     <section className='main-joke'>
-      {data ? data.joke : <Error />};
+      {data ? data.joke : <Error />}
     </section>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["cypress"]
   },
   "include": [
     "src"


### PR DESCRIPTION
# Description

This branch covers the happy and sad path testing for the home page. It intercepts the fetch requests to the dad joke API and stubs a couple mock jokes for the tests. It tests to make sure the page elements render, that a new joke generates when the button is clicked, and that an error message appears for bad fetch requests.

## Type of change

- [x] Cypress tests

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ]  local host
- [ ]  dev tools
- [ ]  terminal
- [x] Cypress

# Related Issues:

- [x]  closes #2 closes #4 

# Checklist:

- [x]  My code follows the Turing's guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  No console error messages