### PR TITLE
Bug: fix page refresh on search bar clear button

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,31 +1,31 @@
-import React, { useState, useEffect } from 'react';
-import { fetchSearch } from '../../apiCalls';
-import './SearchBar.css';
-import { SearchResponse } from '../../apiCalls';
-import Error from '../Error/Error';
+import React, { useState, useEffect } from "react";
+import { fetchSearch } from "../../apiCalls";
+import "./SearchBar.css";
+import { SearchResponse } from "../../apiCalls";
+import Error from "../Error/Error";
 
-type Event = React.ChangeEvent<HTMLInputElement>
-type ClickEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>
+type Event = React.ChangeEvent<HTMLInputElement>;
+type ClickEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>;
 type Props = {
-  displaySearch: (result: SearchResponse | null) => void
-}
+  displaySearch: (result: SearchResponse | null) => void;
+};
 
 const SearchBar = ({ displaySearch }: Props) => {
-  const [term, setTerm] = useState<string>('')
-  const [error, setError] = useState<string>('')
-  const [btnDisable, setBtnDisable] = useState<boolean>(true)
-  const [noResult, setNoResult] = useState<boolean>(false)
+  const [term, setTerm] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [btnDisable, setBtnDisable] = useState<boolean>(true);
+  const [noResult, setNoResult] = useState<boolean>(false);
 
   useEffect(() => {
-    setBtnDisable(!term)
-  }, [term])
+    setBtnDisable(!term);
+  }, [term]);
 
   const searchJokes = (event: ClickEvent) => {
-    setError('');
+    setError("");
     event.preventDefault();
     fetchSearch(term)
-      .then(data => {
-        if(!data?.results.length) {
+      .then((data) => {
+        if (!data?.results.length) {
           setNoResult(true);
           displaySearch(data);
         } else {
@@ -33,26 +33,33 @@ const SearchBar = ({ displaySearch }: Props) => {
           displaySearch(data);
         }
       })
-      .catch(error => setError(error.toString()))
-  }
+      .catch((error) => setError(error.toString()));
+  };
+
+  const clearSearch = (event: ClickEvent) => {
+    event.preventDefault();
+    setTerm("");
+    setNoResult(false);
+    setError("");
+  };
 
   return (
-    <div className='search-form'>
+    <div className="search-form">
       <form>
         <input
-        type='text' 
-        name='term' 
-        placeholder='Search jokes' 
-        value={term} 
-        onChange={(event: Event) => setTerm(event.target.value)} 
-      />
-      <button className='search-btn' disabled={btnDisable} onClick={searchJokes}>&#9906;</button>
-      <button className='clear-btn'>X</button>
+          type="text"
+          name="term"
+          placeholder="Search jokes"
+          value={term}
+          onChange={(event: Event) => setTerm(event.target.value)}
+        />
+        <button className="search-btn" disabled={btnDisable} onClick={searchJokes}>&#9906;</button>
+        <button className="clear-btn" onClick={clearSearch}>X</button>
       </form>
-      {noResult && <p className='no-result-msg'>Sorry! No funny business here, try searching again.</p>}
+      {noResult && (<p className="no-result-msg">Sorry! No funny business here, try searching again.</p>)}
       {error && <Error error={error} />}
     </div>
   );
-}
+};
 
 export default SearchBar;


### PR DESCRIPTION
# Description

- Added clearSearch function to handle page refresh error when user clears search. 

## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- troubleshooted in browser after searching for keywords that exist and don't. 

- [x]  local host
- [x]  dev tools
- [ ]  terminal

# Related Issues:

- [x]  closes #31 
- [ ]  and/or related to #<issue number>

# Checklist:

- [x]  My code follows the Turing's guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  No console error messages