### PR TITLE
Refac/typescript interfaces

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -1,19 +1,5 @@
- export interface JokeResponse {
-  id: string;
-  joke: string;
- }
-
-export interface SearchResponse {
-  "current_page": number,
-  "limit": number,
-  "next_page": number,
-  "previous_page": number,
-  "results": Array<JokeResponse>,
-  "search_term": string,
-  "status": number,
-  "total_jokes": number,
-  "total_pages": number
-}
+import { JokeResponse } from "./interfaces";
+import { SearchResponse } from "./interfaces";
 
 export const fetchJoke = async(): Promise<JokeResponse | null> => {
   return await fetch('https://icanhazdadjoke.com/', {

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -1,7 +1,7 @@
-import { JokeResponse } from "./interfaces";
-import { SearchResponse } from "./interfaces";
+import { IJokeResponse } from "./interfaces";
+import { ISearchResponse } from "./interfaces";
 
-export const fetchJoke = async(): Promise<JokeResponse | null> => {
+export const fetchJoke = async(): Promise<IJokeResponse | null> => {
   return await fetch('https://icanhazdadjoke.com/', {
     headers: {
       'Accept': 'application/json'
@@ -17,7 +17,7 @@ export const fetchJoke = async(): Promise<JokeResponse | null> => {
     })
 };
 
-export const fetchSearch = async(term: string): Promise<SearchResponse | null> => {
+export const fetchSearch = async(term: string): Promise<ISearchResponse | null> => {
   return await fetch(`https://icanhazdadjoke.com/search?term=${term}`, {
     headers: {
       'Accept': 'application/json'

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -6,13 +6,13 @@ import HomePage from '../HomePage/HomePage';
 import SearchPage from '../SearchPage/SearchPage';
 import { fetchJoke } from '../../apiCalls';
 import { Sparkles } from '../Sparkles/Sparkles';
-import { JokeResponse } from '../../interfaces';
+import { IJokeResponse } from '../../interfaces';
 import './App.css';
 
 let sparkles: Array<JSX.Element> = [];
 
 const App = () => {
-  const [data, setData] = useState<JokeResponse | null>({ id: '', joke: '' });
+  const [data, setData] = useState<IJokeResponse | null>({ id: '', joke: '' });
   const [mousePos, setMousePos] = useState({x: 0, y: 0});
   const [error, setError] = useState('');
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { Route, Switch } from 'react-router-dom';
+import Error from '../Error/Error';
 import Header from '../Header/Header';
 import HomePage from '../HomePage/HomePage';
-import Error from '../Error/Error';
 import SearchPage from '../SearchPage/SearchPage';
+import { fetchJoke } from '../../apiCalls';
 import { Sparkles } from '../Sparkles/Sparkles';
+import { JokeResponse } from '../../interfaces';
 import './App.css';
-import { fetchJoke, JokeResponse } from '../../apiCalls';
 
 let sparkles: Array<JSX.Element> = [];
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -10,6 +10,7 @@ import { IJokeResponse } from '../../interfaces';
 import './App.css';
 
 let sparkles: Array<JSX.Element> = [];
+type MoveMouseEvent = React.MouseEvent<HTMLElement, MouseEvent>
 
 const App = () => {
   const [data, setData] = useState<IJokeResponse | null>({ id: '', joke: '' });
@@ -27,8 +28,8 @@ const App = () => {
     .catch(error => { setError(error.toString())})
   }
 
-  const configureSparkles = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    setMousePos({x: e.clientX, y: e.clientY});
+  const configureSparkles = (event: MoveMouseEvent) => {
+    setMousePos({x: event.clientX, y: event.clientY});
     sparkles.push(<Sparkles x={mousePos.x} y={mousePos.y} />);
     setTimeout(() => {sparkles = sparkles.slice(1)}, 500);
   }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
-import './Header.css'
 import { Link } from 'react-router-dom';
 import logo from '../../header-2.png';
+import './Header.css'
 
 const Header = () => {
   return (

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -1,6 +1,6 @@
-import './HomePage.css';
-import { JokeResponse } from '../../apiCalls';
 import Joke from '../Joke/Joke';
+import { JokeResponse } from '../../interfaces';
+import './HomePage.css';
 
 interface Props {
   data: JokeResponse | null;

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -1,9 +1,9 @@
 import Joke from '../Joke/Joke';
-import { JokeResponse } from '../../interfaces';
+import { IJokeResponse } from '../../interfaces';
 import './HomePage.css';
 
 interface Props {
-  data: JokeResponse | null;
+  data: IJokeResponse | null;
   getRandomJoke: Function;
   error: string;
 }

--- a/src/components/Joke/Joke.tsx
+++ b/src/components/Joke/Joke.tsx
@@ -1,5 +1,5 @@
 import './Joke.css'
-import { JokeResponse } from '../../apiCalls'
+import { JokeResponse } from '../../interfaces'
 
 interface Props {
   data: JokeResponse | null;

--- a/src/components/Joke/Joke.tsx
+++ b/src/components/Joke/Joke.tsx
@@ -1,8 +1,8 @@
 import './Joke.css'
-import { JokeResponse } from '../../interfaces'
+import { IJokeResponse } from '../../interfaces'
 
 interface Props {
-  data: JokeResponse | null;
+  data: IJokeResponse | null;
   class: string;
   error?: string;
 }

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -36,7 +36,7 @@ const SearchBar = ({ displaySearch }: Props) => {
       .catch(error => setError(error.toString()))
   }
 
-  const clearSearch = (event: ClickEvent) => {
+  const clearSearch = (event: ClickMouseEvent) => {
     event.preventDefault();
     setTerm('');
     setNoResult(false);

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import Error from '../Error/Error';
 import { fetchSearch } from '../../apiCalls';
-import { SearchResponse } from '../../interfaces';
+import { ISearchResponse } from '../../interfaces';
 import './SearchBar.css';
 
 type Event = React.ChangeEvent<HTMLInputElement>
 type ClickEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>
 interface Props {
-  displaySearch: (result: SearchResponse | null) => void
+  displaySearch: (result: ISearchResponse | null) => void
 }
 
 const SearchBar = ({ displaySearch }: Props) => {

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -5,7 +5,7 @@ import { ISearchResponse } from '../../interfaces';
 import './SearchBar.css';
 
 type Event = React.ChangeEvent<HTMLInputElement>
-type ClickEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>
+type ClickMouseEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>
 interface Props {
   displaySearch: (result: ISearchResponse | null) => void
 }
@@ -20,7 +20,7 @@ const SearchBar = ({ displaySearch }: Props) => {
     setBtnDisable(!term)
   }, [term])
 
-  const searchJokes = (event: ClickEvent) => {
+  const searchJokes = (event: ClickMouseEvent) => {
     setError('');
     event.preventDefault();
     fetchSearch(term)

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { fetchSearch } from '../../apiCalls';
-import './SearchBar.css';
-import { SearchResponse } from '../../apiCalls';
 import Error from '../Error/Error';
+import { fetchSearch } from '../../apiCalls';
+import { SearchResponse } from '../../interfaces';
+import './SearchBar.css';
 
 type Event = React.ChangeEvent<HTMLInputElement>
 type ClickEvent = React.MouseEvent<HTMLButtonElement, MouseEvent>
-type Props = {
+interface Props {
   displaySearch: (result: SearchResponse | null) => void
 }
 

--- a/src/components/SearchPage/SearchPage.tsx
+++ b/src/components/SearchPage/SearchPage.tsx
@@ -1,8 +1,8 @@
-import SearchBar from '../SearchBar/SearchBar';
-import Joke from '../Joke/Joke';
-import './SearchPage.css';
-import { SearchResponse } from '../../apiCalls';
 import { useState } from 'react'
+import Joke from '../Joke/Joke';
+import SearchBar from '../SearchBar/SearchBar';
+import { SearchResponse } from '../../interfaces';
+import './SearchPage.css';
 
 const SearchPage = () => {
   const [searchResult, setSearchResult] = useState<SearchResponse | null>(null);

--- a/src/components/SearchPage/SearchPage.tsx
+++ b/src/components/SearchPage/SearchPage.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import Joke from '../Joke/Joke';
 import SearchBar from '../SearchBar/SearchBar';
-import { SearchResponse } from '../../interfaces';
+import { ISearchResponse } from '../../interfaces';
 import './SearchPage.css';
 
 const SearchPage = () => {
-  const [searchResult, setSearchResult] = useState<SearchResponse | null>(null);
+  const [searchResult, setSearchResult] = useState<ISearchResponse | null>(null);
 
-  const displaySearch = (result: SearchResponse | null) => {
+  const displaySearch = (result: ISearchResponse | null) => {
     setSearchResult(result);
   }
 

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -1,0 +1,16 @@
+export interface JokeResponse {
+  id: string;
+  joke: string;
+ }
+
+ export interface SearchResponse {
+  "current_page": number,
+  "limit": number,
+  "next_page": number,
+  "previous_page": number,
+  "results": Array<JokeResponse>,
+  "search_term": string,
+  "status": number,
+  "total_jokes": number,
+  "total_pages": number
+}

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -1,14 +1,14 @@
-export interface JokeResponse {
+export interface IJokeResponse {
   id: string;
   joke: string;
  }
 
- export interface SearchResponse {
+ export interface ISearchResponse {
   "current_page": number,
   "limit": number,
   "next_page": number,
   "previous_page": number,
-  "results": Array<JokeResponse>,
+  "results": Array<IJokeResponse>,
   "search_term": string,
   "status": number,
   "total_jokes": number,


### PR DESCRIPTION
# Description

This will add a new file in the `src` directory named `interfaces.tsx`. I moved the interfaces in `apiCalls.tsx` into it because we use them in multiple components. I also changed their names to include an "I" prefix because that helps developers know it's an interface. Doublechecked to make sure all components using props have a `Props` interface defined. Didn't add an "I" prefix to those because they seem kind of separate from other interfaces and have a specific task. I also changed instances where we were using events so that they were all fully-typed out (i.e. `e`'s were changed to `event`).

## Type of change

- [x]  Refactoring

# How Has This Been Tested?

I made sure to checkout the page and make sure none of the functionality was lost.

- [x]  local host

# Related Issues:

- [x]  closes #27 

# Checklist:

- [x]  My code follows the Turing's guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  No console error messages (only error messages is the renderDOM one we are waiting to hear back on)