### PR TITLE
Fix: update display search to null on clear search

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -41,6 +41,7 @@ const SearchBar = ({ displaySearch }: Props) => {
     setTerm('');
     setNoResult(false);
     setError('');
+    displaySearch(null)
   };
 
   return (


### PR DESCRIPTION
# Description
- updated clearSearch function to change displaySearch state to null. When clear search button is clicked, all elements will be cleared for a fresh search, including jokes. 
- 
## Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  local host
- [x]  dev tools
- [ ]  terminal

# Related Issues:

- [x]  closes #42 
- [ ]  and/or related to #<issue number>

# Checklist:

- [x]  My code follows the Turing's guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  No console error messages