### PR TITLE
Feat/all search results

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -18,7 +18,7 @@ export const fetchJoke = (): Promise<IJokeResponse | null> => {
 };
 
 export const fetchSearch = (term: string, page: number = 1): Promise<ISearchResponse | null> => {
-  return fetch(`https://icanhazdadjoke.com/search?term=${term}&limit=30&page=${page}`, {
+  return fetch(`https://icanhazdadjoke.com/search?term=${term}&page=${page}`, {
     headers: {
       'Accept': 'application/json'
     }

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -17,8 +17,8 @@ export const fetchJoke = (): Promise<IJokeResponse | null> => {
     })
 };
 
-export const fetchSearch = (term: string, page: number = 1): Promise<ISearchResponse | null> => {
-  return fetch(`https://icanhazdadjoke.com/search?term=${term}&page=${page}`, {
+export const fetchSearch = (searchTerm: string, page: number = 1): Promise<ISearchResponse | null> => {
+  return fetch(`https://icanhazdadjoke.com/search?term=${searchTerm}&page=${page}`, {
     headers: {
       'Accept': 'application/json'
     }
@@ -31,3 +31,6 @@ export const fetchSearch = (term: string, page: number = 1): Promise<ISearchResp
       }
     });
 }
+
+
+

--- a/src/components/SearchBar/SearchBar.css
+++ b/src/components/SearchBar/SearchBar.css
@@ -81,3 +81,7 @@ input {
   margin: 0 2%;
   border-radius: 15px;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/components/SearchBar/SearchBar.css
+++ b/src/components/SearchBar/SearchBar.css
@@ -68,20 +68,3 @@ input {
     box-shadow: 0px 0px 10px #56ff3b, 0px 0px 20px #56ff3b, 0px 0px 30px #56ff3b, 0px 0px 40px #56ff3b, 0px 0px 50px #56ff3b, 0px 0px 75px #56ff3b;
   }
 }
-
-.page-btns {
-  width: 100%;
-  text-align: center;
-}
-
-.prev, .next {
-  background-color: #ff0da2;
-  font-size: 15pt;
-  padding: 1%;
-  margin: 0 2%;
-  border-radius: 15px;
-}
-
-.hidden {
-  display: none;
-}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -16,7 +16,6 @@ const SearchBar = ({ displaySearch }: Props) => {
   const [btnDisable, setBtnDisable] = useState<boolean>(true);
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [noResult, setNoResult] = useState<boolean>(false);
-  const [allJokes, setAllJokes] = useState<IJokeResponse[]>([]);
   const [error, setError] = useState<string>('');
 
   useEffect(() => {
@@ -26,22 +25,22 @@ const SearchBar = ({ displaySearch }: Props) => {
 useEffect(() => {
   if (searchTerm !== "") {
     fetchSearch(searchTerm)
-      .then((data) => {
+      .then(data => {
         let totalPages = data?.total_pages;
         let fetchedJokes: IJokeResponse[] = [];
-        let jokeIds = new Set<string>();
+        let jokeIds: string[] = [];
 
         if (totalPages) {
           const pagePromises = [];
           for (let page = 1; page <= totalPages; page++) {
             pagePromises.push(
-              fetchSearch(searchTerm, page).then((response) => {
+              fetchSearch(searchTerm, page).then(response => {
                 const jokes = response?.results;
                 if (jokes) {
-                  jokes.forEach((joke) => {
-                    if (!jokeIds.has(joke.id)) {
+                  jokes.forEach(joke => {
+                    if (!jokeIds.includes(joke.id)) {
                       fetchedJokes.push(joke);
-                      jokeIds.add(joke.id);
+                      jokeIds.push(joke.id);
                     }
                   });
                 }
@@ -59,20 +58,12 @@ useEffect(() => {
                 displaySearch(fetchedJokes);
               }
             })
-            .catch((error) => {
-              if (error instanceof Error) {
-                setError(String(error));
-              }
-            });
+            .catch(error => { setError(error.toString()) });
         } else {
           displaySearch(fetchedJokes);
         }
       })
-      .catch((error) => {
-        if (error instanceof Error) {
-          setError(String(error));
-        }
-      });
+      .catch(error => { setError(error.toString()) });
   }
 }, [searchTerm]);
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -11,32 +11,64 @@ interface Props {
 }
 
 const SearchBar = ({ displaySearch }: Props) => {
-  const [term, setTerm] = useState<string>('')
-  const [error, setError] = useState<string>('')
-  const [btnDisable, setBtnDisable] = useState<boolean>(true)
-  const [noResult, setNoResult] = useState<boolean>(false)
+  const [term, setTerm] = useState<string>('');
+  const [btnDisable, setBtnDisable] = useState<boolean>(true);
+  const [noResult, setNoResult] = useState<boolean>(false);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(1);
+  const [error, setError] = useState<string>('');
 
   useEffect(() => {
     setBtnDisable(!term)
   }, [term])
 
   const searchJokes = (event: ClickMouseEvent) => {
-    setError('');
     event.preventDefault();
+    setCurrentPage(1);
+    setTotalPages(1);
+    setError('');
     fetchSearch(term)
       .then(data => {
-        const allJokes = data?.results;
-        const totalPages = data?.total_pages
+        console.log('Initial Search: ', data)
+        const jokes = data?.results;
+        data && setTotalPages(data.total_pages);
         
         if(!data?.results.length) {
           setNoResult(true);
-          displaySearch(allJokes);
+          displaySearch(jokes);
         } else {
           setNoResult(false);
-          displaySearch(allJokes);
+          displaySearch(jokes);
         }
       })
       .catch(error => setError(error.toString()))
+  }
+
+  // Conditional logic:
+  // If data.current_page === total_pages, don't show next button
+  // If data.current_page === 1, don't show prev button
+
+  // Logic for pages:
+  // Set state for current page
+
+  const changePage = (button: string) => {
+    let pageDirection: number = button === 'next' ? currentPage + 1 : currentPage - 1;
+    
+    if (currentPage !== totalPages) {
+      fetchSearch(term, pageDirection)
+      .then(data => {
+        data && setCurrentPage(data?.current_page);
+        const jokes = data?.results;
+        if(!data?.results.length) {
+          setNoResult(true);
+          displaySearch(jokes);
+        } else {
+          setNoResult(false);
+          displaySearch(jokes);
+        }
+      })
+      .catch(error => setError(error.toString()))
+    }
   }
 
   const clearSearch = (event: ClickMouseEvent) => {
@@ -60,7 +92,10 @@ const SearchBar = ({ displaySearch }: Props) => {
       <button className='search-btn' disabled={btnDisable} onClick={searchJokes}>&#9906;</button>
       <button className='clear-btn' onClick={clearSearch}>X</button>
       </form>
-      <div className='page-btns'><button className='prev'>← Previous Page</button><button className='next'>Next Page →</button></div>
+      <div className='page-btns'>
+        <button className='prev' onClick={() => changePage('prev')}>← Previous Page</button>
+        <button className='next' onClick={() => changePage('next')}>Next Page →</button>
+      </div>
       {noResult && <p className='no-result-msg'>Sorry! No funny business here, try searching again.</p>}
       {error && <Error error={error} />}
     </div>


### PR DESCRIPTION
# Description

This branch adds functionality so when the user enters a search term, multiple fetch requests are made to the API for each page of jokes so all jokes matching that term render on the page. This removes the `prev`/`next` buttons as they are no longer needed. All styling and references to those buttons are removed.

## Type of change

Please delete options that are not relevant.

- [x]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  local host
- [x]  dev tools

# Related Issues:

- [x]  closes #47 

# Checklist:

- [x]  My code follows the Turing's guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  No console error messages